### PR TITLE
fix(input-license): Fix autocomplete in input and add license MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jefferson Leon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/content.js
+++ b/content.js
@@ -198,7 +198,7 @@
       </div>
       <div class="adder">
         <div class="time" id="curr-time">00:00</div>
-        <input id="note-input" type="text" placeholder="Write a note…">
+        <input id="note-input" type="text" placeholder="Write a note…" autocomplete="off"/>
         <button class="btn" id="save-note">Save</button>
       </div>
       <div class="list" id="notes-list"></div>


### PR DESCRIPTION
## ✨ Summary
Fixes the **autocomplete** behavior on the input field and adds the **MIT** license to the repository.

## 📌 What’s included?
- Sets the input’s `autocomplete` attribute to prevent unwanted browser suggestions and conflicts with player shortcuts.
- Adds a `LICENSE` file with the official **MIT License**.

## 🧪 How to test
1. Open a page where the input is rendered.
2. Focus the field and type normally.
3. Verify that:
   - No unexpected browser autofill/autocomplete popups appear.
   - Player keyboard shortcuts do not trigger while typing.
4. Confirm the `LICENSE` file exists and the repo reflects **MIT** as the license.

## ✅ Checklist
- [ ] No breaking changes or API modifications.
- [ ] License metadata updated.

## 📓 Changelog notes
- fix: correct input `autocomplete` to avoid unwanted suggestions.
- chore: add MIT license file.